### PR TITLE
Update GitHub Actions versions and Sonar scan args

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
   build-analyze:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build and analyze on SonarQube
         env:
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - name: Build and analyze on SonarQube
         env:
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - name: Build and analyze on SonarQube
         env:
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/build-analyze.sh
+++ b/build-analyze.sh
@@ -20,7 +20,7 @@ export PATH=$HOME/.sonar/build-wrapper-linux-x86:$PATH
 # Download sonar-scanner
 curl -sSLo $HOME/.sonar/sonar-scanner.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-$SONAR_SCANNER_VERSION-linux-x64.zip 
 unzip -o $HOME/.sonar/sonar-scanner.zip -d $HOME/.sonar/
-export PATH=$HOME/.sonar/sonar-scanner-$SONAR_SCANNER_VERSION-linux/bin:$PATH
+export PATH=$HOME/.sonar/sonar-scanner-$SONAR_SCANNER_VERSION-linux-x64/bin:$PATH
 
 # Setup the build system
 autoreconf --install

--- a/build-analyze.sh
+++ b/build-analyze.sh
@@ -18,7 +18,7 @@ unzip -o $HOME/.sonar/build-wrapper-linux-x86.zip -d $HOME/.sonar/
 export PATH=$HOME/.sonar/build-wrapper-linux-x86:$PATH
 
 # Download sonar-scanner
-curl -sSLo $HOME/.sonar/sonar-scanner.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-$SONAR_SCANNER_VERSION-linux.zip 
+curl -sSLo $HOME/.sonar/sonar-scanner.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-$SONAR_SCANNER_VERSION-linux-x64.zip 
 unzip -o $HOME/.sonar/sonar-scanner.zip -d $HOME/.sonar/
 export PATH=$HOME/.sonar/sonar-scanner-$SONAR_SCANNER_VERSION-linux/bin:$PATH
 

--- a/build-analyze.sh
+++ b/build-analyze.sh
@@ -6,7 +6,7 @@ git fetch --unshallow
 
 export SONAR_HOST_URL="${SONAR_HOST_URL}" # Comes from a Github secret
 #export SONAR_TOKEN= # Access token coming from SonarQube projet creation page. In this example, it is defined in the environement through a Github secret.
-export SONAR_SCANNER_VERSION="5.0.1.3006" # Find the latest version in the "Linux" link on this page:
+export SONAR_SCANNER_VERSION="8.0.1.6346" # Find the latest version in the "Linux" link on this page:
                                           # https://docs.sonarqube.org/latest/analysis/scan/sonarscanner/
 export BUILD_WRAPPER_OUT_DIR="bw-output" # Directory where build-wrapper output will be placed
 


### PR DESCRIPTION
This PR updates GitHub Actions workflow dependencies and Sonar scan configuration.

Changes:
- Update `SonarSource/sonarqube-scan-action` and `install-build-wrapper` to `v7`
- Update `actions/checkout` to `v6`
- Normalize Sonar scan `args` formatting to match the updated example style
- Update additional workflow actions to current latest versions used in this repository
- Fix remaining `actionlint` findings